### PR TITLE
Fix dark theme splash screen background

### DIFF
--- a/core/resources/src/main/res/values-night/themes.xml
+++ b/core/resources/src/main/res/values-night/themes.xml
@@ -14,11 +14,16 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="NightAdjusted.Theme.GoCart" parent="android:Theme.Material.NoActionBar" />
 
-    <style name="Theme.GoCart.SplashScreen" parent="NightAdjusted.Theme.GoCart">
+    <style name="NightAdjusted.Theme.SplashScreen" parent="Theme.SplashScreen">
+        <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="27">false</item>
+    </style>
+
+    <style name="Theme.GoCart.SplashScreen" parent="NightAdjusted.Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/black</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_go_cart_logo</item>
 

--- a/core/resources/src/main/res/values-night/themes.xml
+++ b/core/resources/src/main/res/values-night/themes.xml
@@ -14,13 +14,16 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
     <style name="NightAdjusted.Theme.GoCart" parent="android:Theme.Material.NoActionBar" />
 
-    <style name="NightAdjusted.Theme.SplashScreen" parent="Theme.SplashScreen">
-        <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="27">false</item>
+    <style name="Theme.GoCart.SplashScreen" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_go_cart_logo</item>
+
+        <!-- Set the theme of the Activity that directly follows the splash screen. -->
+        <item name="postSplashScreenTheme">@style/Theme.GoCart</item>
     </style>
 
 </resources>

--- a/core/resources/src/main/res/values-night/themes.xml
+++ b/core/resources/src/main/res/values-night/themes.xml
@@ -18,7 +18,7 @@
 
     <style name="NightAdjusted.Theme.GoCart" parent="android:Theme.Material.NoActionBar" />
 
-    <style name="Theme.GoCart.SplashScreen" parent="Theme.SplashScreen">
+    <style name="Theme.GoCart.SplashScreen" parent="NightAdjusted.Theme.GoCart">
         <item name="windowSplashScreenBackground">@color/black</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_go_cart_logo</item>
 

--- a/core/resources/src/main/res/values/themes.xml
+++ b/core/resources/src/main/res/values/themes.xml
@@ -27,7 +27,7 @@
         <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
     </style>
 
-    <style name="Theme.GoCart.SplashScreen" parent="NightAdjusted.Theme.Splash">
+    <style name="Theme.GoCart.SplashScreen" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/white</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_go_cart_logo</item>
 

--- a/core/resources/src/main/res/values/themes.xml
+++ b/core/resources/src/main/res/values/themes.xml
@@ -27,7 +27,7 @@
         <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
     </style>
 
-    <style name="Theme.GoCart.SplashScreen" parent="Theme.SplashScreen">
+    <style name="Theme.GoCart.SplashScreen" parent="NightAdjusted.Theme.Splash">
         <item name="windowSplashScreenBackground">@color/white</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_go_cart_logo</item>
 


### PR DESCRIPTION
The issue was that, for the SplashScreen style, you were using `NightAdjusted.Theme.Splash` as the parent theme instead of `Theme.SplashScreen`.

This closes  #150 